### PR TITLE
Add checks for kotlin version `1.8.0` or greater

### DIFF
--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/KmpConfigurationExtension.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/KmpConfigurationExtension.kt
@@ -27,6 +27,7 @@ import javax.inject.Inject
 
 @KmpConfigurationDsl
 public abstract class KmpConfigurationExtension @Inject internal constructor(
+    private val kotlinPluginVersion: KotlinVersion,
     private val isKmpTargetsAllSet: Boolean,
     private val kmpTargetsProperty: Set<KmpTargetProperty>?,
     private val configureContainers: Action<Set<Container>>,
@@ -41,7 +42,12 @@ public abstract class KmpConfigurationExtension @Inject internal constructor(
             isConfigured = true
 
             val containers = mutableSetOf<Container>()
-            val holder = ContainerHolder.instance(containers, isKmpTargetsAllSet, kmpTargetsProperty)
+            val holder = ContainerHolder.instance(
+                kotlinPluginVersion,
+                containers,
+                isKmpTargetsAllSet,
+                kmpTargetsProperty
+            )
             action.execute(KmpConfigurationContainerDsl.instance(holder))
             configureContainers.execute(containers.sortedBy { it.sortOrder }.toSet())
         }

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/ContainerHolder.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/ContainerHolder.kt
@@ -20,6 +20,7 @@ import io.matthewnelson.kmp.configuration.extension.container.target.*
 import io.matthewnelson.kmp.configuration.extension.container.target.KmpTargetProperty.Companion.property
 
 public class ContainerHolder private constructor(
+    internal val kotlinPluginVersion: KotlinVersion,
     private val containers: MutableSet<Container>,
     private val isKmpTargetsAllSet: Boolean,
     private val kmpTargetsProperty: Set<KmpTargetProperty>?,
@@ -50,11 +51,13 @@ public class ContainerHolder private constructor(
     internal companion object {
         @JvmSynthetic
         internal fun instance(
+            kotlinPluginVersion: KotlinVersion,
             containers: MutableSet<Container>,
             isKmpTargetsAllSet: Boolean,
             kmpTargetsProperty: Set<KmpTargetProperty>?,
         ): ContainerHolder {
             return ContainerHolder(
+                kotlinPluginVersion,
                 containers,
                 isKmpTargetsAllSet,
                 kmpTargetsProperty

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetWatchosContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetWatchosContainer.kt
@@ -19,6 +19,7 @@ package io.matthewnelson.kmp.configuration.extension.container.target
 import io.matthewnelson.kmp.configuration.KmpConfigurationDsl
 import io.matthewnelson.kmp.configuration.extension.container.ContainerHolder
 import org.gradle.api.Action
+import org.gradle.api.GradleException
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithSimulatorTests
@@ -33,7 +34,9 @@ public sealed class TargetWatchosContainer<T: KotlinNativeTarget> private constr
         public fun watchosAll() {
             watchosArm32()
             watchosArm64()
-            watchosDeviceArm64()
+            if (holder.kotlinPluginVersion.isAtLeast(1, 8)) {
+                watchosDeviceArm64()
+            }
             watchosX64()
             watchosX86()
             watchosSimulatorArm64()
@@ -70,6 +73,10 @@ public sealed class TargetWatchosContainer<T: KotlinNativeTarget> private constr
         }
 
         public fun watchosDeviceArm64(targetName: String, action: Action<DeviceArm64>) {
+            if (!holder.kotlinPluginVersion.isAtLeast(1, 8)) {
+                throw GradleException("watchosDeviceArm64 requires Kotlin 1.8.0 or greater")
+            }
+
             val container = holder.find(targetName) ?: DeviceArm64(targetName)
             action.execute(container)
             holder.add(container)


### PR DESCRIPTION
Closes #1 

This PR adds a check for Kotlin version `1.8.0` in order to:
 - See if checking for android version 2 source set layout is needed
 - If `watchosDeviceArm64` is available for configuring