### PR TITLE
Change `KmpTargetProperty` visibility to `internal`

### DIFF
--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/KmpTargetProperty.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/KmpTargetProperty.kt
@@ -19,7 +19,7 @@ package io.matthewnelson.kmp.configuration.extension.container.target
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 
-public enum class KmpTargetProperty {
+internal enum class KmpTargetProperty {
     ANDROID,
     ANDROID_ARM32,
     ANDROID_ARM64,


### PR DESCRIPTION
Closes #5 

This PR modifies the public API by modifying the visibility of `KmpTargetProperty` from `public` to `internal`