### PR TITLE
Use `Action` instead of passing `Function` for Kotlin APIs

### DIFF
--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/KmpConfigurationContainerDsl.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/KmpConfigurationContainerDsl.kt
@@ -52,7 +52,6 @@ public class KmpConfigurationContainerDsl private constructor(
     }
 
     internal companion object {
-        internal const val NAME: String = "kmpConfiguration"
         @JvmSynthetic
         internal fun instance(holder: ContainerHolder) = KmpConfigurationContainerDsl(holder)
     }

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetAndroidContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetAndroidContainer.kt
@@ -120,15 +120,16 @@ public sealed class TargetAndroidContainer<T: TestedExtension> private construct
     @JvmSynthetic
     internal final override fun setup(kotlin: KotlinMultiplatformExtension) {
         with(kotlin) {
-            val target = android(targetName) t@ {
+            @Suppress("RedundantSamConstructor")
+            val target = android(targetName, Action { t ->
                 kotlinJvmTarget?.let { version ->
-                    compilations.all {
+                    t.compilations.all {
                         it.kotlinOptions.jvmTarget = version.toString()
                     }
                 }
 
-                lazyTarget?.execute(this@t)
-            }
+                lazyTarget?.execute(t)
+            })
 
             applyPlugins(target.project)
 

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetAndroidNativeContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetAndroidNativeContainer.kt
@@ -107,26 +107,27 @@ public sealed class TargetAndroidNativeContainer<T: KotlinNativeTarget> private 
     @JvmSynthetic
     internal final override fun setup(kotlin: KotlinMultiplatformExtension) {
         with(kotlin) {
+            @Suppress("RedundantSamConstructor")
             val target = when (this@TargetAndroidNativeContainer) {
                 is Arm32 -> {
-                    androidNativeArm32(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    androidNativeArm32(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is Arm64 -> {
-                    androidNativeArm64(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    androidNativeArm64(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is X64 -> {
-                    androidNativeX64(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    androidNativeX64(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is X86 -> {
-                    androidNativeX86(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    androidNativeX86(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
             }
 

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetIosContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetIosContainer.kt
@@ -108,26 +108,27 @@ public sealed class TargetIosContainer<T: KotlinNativeTarget> private constructo
     @JvmSynthetic
     internal final override fun setup(kotlin: KotlinMultiplatformExtension) {
         with(kotlin) {
+            @Suppress("RedundantSamConstructor")
             val target = when (this@TargetIosContainer) {
                 is Arm32 -> {
-                    iosArm32(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    iosArm32(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is Arm64 -> {
-                    iosArm64(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    iosArm64(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is SimulatorArm64 -> {
-                    iosSimulatorArm64(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    iosSimulatorArm64(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is X64 -> {
-                    iosX64(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    iosX64(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
             }
 

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetJsContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetJsContainer.kt
@@ -34,17 +34,18 @@ public class TargetJsContainer internal constructor(
 
         public fun js() {
             js { container ->
+                @Suppress("RedundantSamConstructor")
                 container.target { dsl ->
-                    dsl.browser {
-                        testTask {
-                            useMocha { timeout = "30s" }
-                        }
-                    }
-                    dsl.nodejs {
-                        testTask {
-                            useMocha { timeout = "30s" }
-                        }
-                    }
+                    dsl.browser( Action { bDsl ->
+                        bDsl.testTask( Action { tDsl ->
+                            tDsl.useMocha( Action { it.timeout = "30s" } )
+                        })
+                    })
+                    dsl.nodejs( Action { nDsl ->
+                        nDsl.testTask( Action { tDsl ->
+                            tDsl.useMocha( Action { it.timeout = "30s" } )
+                        })
+                    })
                 }
             }
         }

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetJsContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetJsContainer.kt
@@ -64,13 +64,14 @@ public class TargetJsContainer internal constructor(
     @JvmSynthetic
     internal override fun setup(kotlin: KotlinMultiplatformExtension) {
         with(kotlin) {
+            @Suppress("RedundantSamConstructor")
             val target = compilerType?.let { type ->
-                js(targetName, type) t@ {
-                    lazyTarget?.execute(this@t)
-                }
-            } ?: js(targetName) t@ {
-                lazyTarget?.execute(this@t)
-            }
+                js(targetName, type, Action { t ->
+                    lazyTarget?.execute(t)
+                })
+            } ?: js(targetName, Action { t ->
+                lazyTarget?.execute(t)
+            })
 
             applyPlugins(target.project)
 

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetJvmContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetJvmContainer.kt
@@ -46,23 +46,23 @@ public class TargetJvmContainer internal constructor(
     @JvmSynthetic
     internal override fun setup(kotlin: KotlinMultiplatformExtension) {
         with(kotlin) {
-            val target = jvm(targetName) t@ {
+            val target = jvm(targetName, Action { t ->
                 kotlinJvmTarget?.let { version ->
-                    compilations.all {
+                    t.compilations.all {
                         it.kotlinOptions.jvmTarget = version.toString()
                     }
                 }
 
-                lazyTarget?.execute(this@t)
+                lazyTarget?.execute(t)
 
-                if (!withJavaEnabled) return@t
+                if (!t.withJavaEnabled) return@Action
 
                 val sCompatibility = compileSourceCompatibility
                 val tCompatibility = compileTargetCompatibility
 
-                if (sCompatibility == null && tCompatibility == null) return@t
+                if (sCompatibility == null && tCompatibility == null) return@Action
 
-                project.extensions.configure(JavaPluginExtension::class.java) { extension ->
+                t.project.extensions.configure(JavaPluginExtension::class.java) { extension ->
                     if (sCompatibility != null) {
                         extension.sourceCompatibility = sCompatibility
                     }
@@ -70,7 +70,7 @@ public class TargetJvmContainer internal constructor(
                         extension.targetCompatibility = tCompatibility
                     }
                 }
-            }
+            })
 
             applyPlugins(target.project)
 

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetLinuxContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetLinuxContainer.kt
@@ -125,31 +125,32 @@ public sealed class TargetLinuxContainer<T: KotlinNativeTarget> private construc
     @JvmSynthetic
     internal final override fun setup(kotlin: KotlinMultiplatformExtension) {
         with(kotlin) {
+            @Suppress("RedundantSamConstructor")
             val target = when (this@TargetLinuxContainer) {
                 is Arm32Hfp -> {
-                    linuxArm32Hfp(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    linuxArm32Hfp(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is Arm64 -> {
-                    linuxArm64(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    linuxArm64(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is Mips32 -> {
-                    linuxMips32(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    linuxMips32(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is Mipsel32 -> {
-                    linuxMipsel32(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    linuxMipsel32(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is X64 -> {
-                    linuxX64(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    linuxX64(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
             }
 

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetMacosContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetMacosContainer.kt
@@ -72,16 +72,17 @@ public sealed class TargetMacosContainer<T: KotlinNativeTarget> private construc
     @JvmSynthetic
     internal final override fun setup(kotlin: KotlinMultiplatformExtension) {
         with(kotlin) {
+            @Suppress("RedundantSamConstructor")
             val target = when (this@TargetMacosContainer) {
                 is Arm64 -> {
-                    macosArm64(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    macosArm64(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is X64 -> {
-                    macosX64(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    macosX64(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
             }
 

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetMingwContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetMingwContainer.kt
@@ -72,16 +72,17 @@ public sealed class TargetMingwContainer<T: KotlinNativeTarget> private construc
     @JvmSynthetic
     internal override fun setup(kotlin: KotlinMultiplatformExtension) {
         with(kotlin) {
+            @Suppress("RedundantSamConstructor")
             val target = when (this@TargetMingwContainer) {
                 is X64 -> {
-                    mingwX64(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    mingwX64(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is X86 -> {
-                    mingwX86(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    mingwX86(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
             }
 

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetTvosContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetTvosContainer.kt
@@ -91,21 +91,22 @@ public sealed class TargetTvosContainer<T: KotlinNativeTarget> private construct
     @JvmSynthetic
     internal override fun setup(kotlin: KotlinMultiplatformExtension) {
         with(kotlin) {
+            @Suppress("RedundantSamConstructor")
             val target = when (this@TargetTvosContainer) {
                 is Arm64 -> {
-                    tvosArm64(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    tvosArm64(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is SimulatorArm64 -> {
-                    tvosSimulatorArm64(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    tvosSimulatorArm64(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is X64 -> {
-                    tvosX64(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    tvosX64(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
             }
 

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetWasmContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetWasmContainer.kt
@@ -34,22 +34,23 @@ public class TargetWasmContainer internal constructor(
         @ExperimentalWasmDsl
         public fun wasm() {
             wasm { container ->
+                @Suppress("RedundantSamConstructor")
                 container.target { dsl ->
-                    dsl.browser {
-                        testTask {
-                            useMocha { timeout = "30s" }
-                        }
-                    }
-                    dsl.nodejs {
-                        testTask {
-                            useMocha { timeout = "30s" }
-                        }
-                    }
-                    dsl.d8 {
-                        testTask {
-                            useMocha { timeout = "30s" }
-                        }
-                    }
+                    dsl.browser( Action { bDsl ->
+                        bDsl.testTask( Action { tDsl ->
+                            tDsl.useMocha( Action { it.timeout = "30s" } )
+                        })
+                    })
+                    dsl.nodejs( Action { nDsl ->
+                        nDsl.testTask( Action { tDsl ->
+                            tDsl.useMocha( Action { it.timeout = "30s" } )
+                        })
+                    })
+                    dsl.d8( Action { dDsl ->
+                        dDsl.testTask( Action { tDsl ->
+                            tDsl.useMocha( Action { it.timeout = "30s" } )
+                        })
+                    })
                 }
             }
         }

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetWasmContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetWasmContainer.kt
@@ -76,9 +76,10 @@ public class TargetWasmContainer internal constructor(
     @OptIn(ExperimentalWasmDsl::class)
     internal override fun setup(kotlin: KotlinMultiplatformExtension) {
         with(kotlin) {
-            val target = wasm(targetName) t@ {
-                lazyTarget?.execute(this@t)
-            }
+            @Suppress("RedundantSamConstructor")
+            val target = wasm(targetName, Action { t ->
+                lazyTarget?.execute(t)
+            })
 
             applyPlugins(target.project)
 

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetWasmNativeContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetWasmNativeContainer.kt
@@ -55,11 +55,12 @@ public sealed class TargetWasmNativeContainer<T: KotlinNativeTarget> private con
     @JvmSynthetic
     internal final override fun setup(kotlin: KotlinMultiplatformExtension) {
         with(kotlin) {
+            @Suppress("RedundantSamConstructor")
             val target = when (this@TargetWasmNativeContainer) {
                 is _32 -> {
-                    wasm32(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    wasm32(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
             }
 

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetWatchosContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetWatchosContainer.kt
@@ -152,36 +152,37 @@ public sealed class TargetWatchosContainer<T: KotlinNativeTarget> private constr
     @JvmSynthetic
     internal override fun setup(kotlin: KotlinMultiplatformExtension) {
         with(kotlin) {
+            @Suppress("RedundantSamConstructor")
             val target = when (this@TargetWatchosContainer) {
                 is Arm32 -> {
-                    watchosArm32(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    watchosArm32(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is Arm64 -> {
-                    watchosArm64(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    watchosArm64(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is DeviceArm64 -> {
-                    watchosDeviceArm64(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    watchosDeviceArm64(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is SimulatorArm64 -> {
-                    watchosSimulatorArm64(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    watchosSimulatorArm64(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is X64 -> {
-                    watchosX64(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    watchosX64(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
                 is X86 -> {
-                    watchosX86(targetName) t@ {
-                        lazyTarget?.execute(this@t)
-                    }
+                    watchosX86(targetName, Action { t ->
+                        lazyTarget?.execute(t)
+                    })
                 }
             }
 


### PR DESCRIPTION
Closes #14 

This PR removes all usage of Kotlin APIs where a `Function` is passed, with the alternative method that accepts `Action`. This is to mitigate any potential future API breaking changes like the one introduced in `1.8.20-Beta`.