### PR TITLE
Bump dependencies

### DIFF
--- a/build-logic/src/main/kotlin/shared.gradle.kts
+++ b/build-logic/src/main/kotlin/shared.gradle.kts
@@ -31,13 +31,13 @@ repositories {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 tasks.withType(KotlinCompile::class.java) {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_1_8)
+        jvmTarget.set(JvmTarget.JVM_11)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 android = "7.4.1"
-kotlin = "1.8.0"
+kotlin = "1.8.10"
 publish = "0.24.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-android = "7.3.1"
+android = "7.4.1"
 kotlin = "1.8.0"
 publish = "0.24.0"
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -4,5 +4,5 @@ zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 
 # https://gradle.org/release-checksums/
-distributionSha256Sum=312eb12875e1747e05c2f81a4789902d7e4ec5defbd1eefeaccc08acf096505d
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
+distributionSha256Sum=948d1e4ccc2f6ae36cbfa087d827aaca51403acae5411e664a6000bb47946f22
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0.1-all.zip


### PR DESCRIPTION
This PR:
 - Updates AGP to `7.4.1`
 - Increases minimum supported Java version to `11` (AGP requirement)
 - Updates KGP to `1.8.10`
 - Updates Gradle Wrapper to `8.0.1`