### PR TITLE
Add support for composite builds

### DIFF
--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
     compileOnly(libs.gradle.android)
 }
 
-signing {
-    useGpgCmd()
+if (!findProperty("VERSION_NAME")!!.toString().endsWith("SNAPSHOT")) {
+    signing {
+        useGpgCmd()
+    }
 }

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/CommonContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/CommonContainer.kt
@@ -25,8 +25,11 @@ public class CommonContainer internal constructor(): Container.ConfigurableTarge
     @JvmSynthetic
     internal override fun setup(kotlin: KotlinMultiplatformExtension) {
         with(kotlin.sourceSets) {
-            lazySourceSetMain?.execute(getByName(KotlinSourceSet.COMMON_MAIN_SOURCE_SET_NAME))
-            lazySourceSetTest?.execute(getByName(KotlinSourceSet.COMMON_TEST_SOURCE_SET_NAME))
+            val commonMain = getByName(KotlinSourceSet.COMMON_MAIN_SOURCE_SET_NAME)
+            lazySourceSetMain.forEach { action -> action.execute(commonMain) }
+
+            val commonTest = getByName(KotlinSourceSet.COMMON_TEST_SOURCE_SET_NAME)
+            lazySourceSetTest.forEach { action -> action.execute(commonTest) }
         }
 
         // setup is only ever called if there is at least 1 target enabled,

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/Container.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/Container.kt
@@ -33,13 +33,11 @@ public sealed class Container {
         private val pluginIds: MutableSet<String> = mutableSetOf()
         public fun pluginIds(vararg ids: String) { pluginIds += ids.toSet() }
 
-        protected var lazySourceSetMain: Action<KotlinSourceSet>? = null
-            private set
-        public fun sourceSetMain(action: Action<KotlinSourceSet>) { lazySourceSetMain = action }
+        protected val lazySourceSetMain: MutableList<Action<KotlinSourceSet>> = mutableListOf()
+        public fun sourceSetMain(action: Action<KotlinSourceSet>) { lazySourceSetMain.add(action) }
 
-        protected var lazySourceSetTest: Action<KotlinSourceSet>? = null
-            private set
-        public fun sourceSetTest(action: Action<KotlinSourceSet>) { lazySourceSetTest = action }
+        protected val lazySourceSetTest: MutableList<Action<KotlinSourceSet>> = mutableListOf()
+        public fun sourceSetTest(action: Action<KotlinSourceSet>) { lazySourceSetTest.add(action) }
 
         protected fun applyPlugins(project: Project) {
             for (id in pluginIds) {

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/ContainerHolder.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/ContainerHolder.kt
@@ -43,6 +43,16 @@ public class ContainerHolder private constructor(
     }
 
     @JvmSynthetic
+    internal fun findCommonContainer(): CommonContainer? {
+        return containers.filterIsInstance<CommonContainer>().firstOrNull()
+    }
+
+    @JvmSynthetic
+    internal fun findKotlinContainer(): KotlinExtensionActionContainer? {
+        return containers.filterIsInstance<KotlinExtensionActionContainer>().firstOrNull()
+    }
+
+    @JvmSynthetic
     internal inline fun <reified T: KmpTarget<*>> find(targetName: String): T? {
         return containers.filterIsInstance<T>().find { targetName == it.targetName }
     }

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/KotlinExtensionActionContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/KotlinExtensionActionContainer.kt
@@ -20,14 +20,16 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 internal class KotlinExtensionActionContainer internal constructor(): Container() {
 
-    private var lazyKotlin: Action<KotlinMultiplatformExtension>? = null
+    private val lazyKotlin = mutableListOf<Action<KotlinMultiplatformExtension>>()
 
     @JvmSynthetic
-    internal fun kotlin(action: Action<KotlinMultiplatformExtension>) { lazyKotlin = action }
+    internal fun kotlin(action: Action<KotlinMultiplatformExtension>) { lazyKotlin.add(action) }
 
     @JvmSynthetic
     internal override fun setup(kotlin: KotlinMultiplatformExtension) {
-        lazyKotlin?.execute(kotlin)
+        lazyKotlin.forEach { action ->
+            action.execute(kotlin)
+        }
     }
 
     @JvmSynthetic

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/KmpConfigurationContainerDsl.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/KmpConfigurationContainerDsl.kt
@@ -40,13 +40,13 @@ public class KmpConfigurationContainerDsl private constructor(
 {
 
     public fun common(action: Action<CommonContainer>) {
-        val container = CommonContainer()
+        val container = holder.findCommonContainer() ?: CommonContainer()
         action.execute(container)
         holder.add(container)
     }
 
     public fun kotlin(action: Action<KotlinMultiplatformExtension>) {
-        val container = KotlinExtensionActionContainer()
+        val container = holder.findKotlinContainer() ?: KotlinExtensionActionContainer()
         container.kotlin(action)
         holder.add(container)
     }

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/KmpTarget.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/KmpTarget.kt
@@ -25,9 +25,8 @@ public sealed class KmpTarget<T: KotlinTarget> private constructor(
     internal val targetName: String
 ): Container.ConfigurableTarget() {
 
-    protected var lazyTarget: Action<T>? = null
-        private set
-    public fun target(action: Action<T>) { lazyTarget = action }
+    protected val lazyTarget: MutableList<Action<T>> = mutableListOf()
+    public fun target(action: Action<T>) { lazyTarget.add(action) }
 
     public sealed class Jvm<T: KotlinTarget>(targetName: String): KmpTarget<T>(targetName) {
 

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetAndroidNativeContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetAndroidNativeContainer.kt
@@ -111,22 +111,22 @@ public sealed class TargetAndroidNativeContainer<T: KotlinNativeTarget> private 
             val target = when (this@TargetAndroidNativeContainer) {
                 is Arm32 -> {
                     androidNativeArm32(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is Arm64 -> {
                     androidNativeArm64(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is X64 -> {
                     androidNativeX64(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is X86 -> {
                     androidNativeX86(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
             }
@@ -136,11 +136,11 @@ public sealed class TargetAndroidNativeContainer<T: KotlinNativeTarget> private 
             with(sourceSets) {
                 getByName("${targetName}Main") { ss ->
                     ss.dependsOn(getByName("${ANDROID_NATIVE}Main"))
-                    lazySourceSetMain?.execute(ss)
+                    lazySourceSetMain.forEach { action -> action.execute(ss) }
                 }
                 getByName("${targetName}Test") { ss ->
                     ss.dependsOn(getByName("${ANDROID_NATIVE}Test"))
-                    lazySourceSetTest?.execute(ss)
+                    lazySourceSetTest.forEach { action -> action.execute(ss) }
                 }
             }
         }

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetIosContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetIosContainer.kt
@@ -112,22 +112,22 @@ public sealed class TargetIosContainer<T: KotlinNativeTarget> private constructo
             val target = when (this@TargetIosContainer) {
                 is Arm32 -> {
                     iosArm32(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is Arm64 -> {
                     iosArm64(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is SimulatorArm64 -> {
                     iosSimulatorArm64(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is X64 -> {
                     iosX64(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
             }
@@ -137,11 +137,11 @@ public sealed class TargetIosContainer<T: KotlinNativeTarget> private constructo
             with(sourceSets) {
                 getByName("${targetName}Main") { ss ->
                     ss.dependsOn(getByName("${IOS}Main"))
-                    lazySourceSetMain?.execute(ss)
+                    lazySourceSetMain.forEach { action -> action.execute(ss) }
                 }
                 getByName("${targetName}Test") { ss ->
                     ss.dependsOn(getByName("${IOS}Test"))
-                    lazySourceSetTest?.execute(ss)
+                    lazySourceSetTest.forEach { action -> action.execute(ss) }
                 }
             }
         }

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetJsContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetJsContainer.kt
@@ -67,10 +67,10 @@ public class TargetJsContainer internal constructor(
             @Suppress("RedundantSamConstructor")
             val target = compilerType?.let { type ->
                 js(targetName, type, Action { t ->
-                    lazyTarget?.execute(t)
+                    lazyTarget.forEach { action -> action.execute(t) }
                 })
             } ?: js(targetName, Action { t ->
-                lazyTarget?.execute(t)
+                lazyTarget.forEach { action -> action.execute(t) }
             })
 
             applyPlugins(target.project)
@@ -78,11 +78,11 @@ public class TargetJsContainer internal constructor(
             with(sourceSets) {
                 getByName("${targetName}Main") { ss ->
                     ss.dependsOn(getByName("${NON_JVM}Main"))
-                    lazySourceSetMain?.execute(ss)
+                    lazySourceSetMain.forEach { action -> action.execute(ss) }
                 }
                 getByName("${targetName}Test") { ss ->
                     ss.dependsOn(getByName("${NON_JVM}Test"))
-                    lazySourceSetTest?.execute(ss)
+                    lazySourceSetTest.forEach { action -> action.execute(ss) }
                 }
             }
         }

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetJvmContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetJvmContainer.kt
@@ -53,7 +53,7 @@ public class TargetJvmContainer internal constructor(
                     }
                 }
 
-                lazyTarget?.execute(t)
+                lazyTarget.forEach { action -> action.execute(t) }
 
                 if (!t.withJavaEnabled) return@Action
 
@@ -77,11 +77,11 @@ public class TargetJvmContainer internal constructor(
             with(sourceSets) {
                 getByName("${targetName}Main") { ss ->
                     ss.dependsOn(getByName("${JVM_ANDROID}Main"))
-                    lazySourceSetMain?.execute(ss)
+                    lazySourceSetMain.forEach { action -> action.execute(ss) }
                 }
                 getByName("${targetName}Test") { ss ->
                     ss.dependsOn(getByName("${JVM_ANDROID}Test"))
-                    lazySourceSetTest?.execute(ss)
+                    lazySourceSetTest.forEach { action -> action.execute(ss) }
                 }
             }
         }

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetLinuxContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetLinuxContainer.kt
@@ -129,27 +129,27 @@ public sealed class TargetLinuxContainer<T: KotlinNativeTarget> private construc
             val target = when (this@TargetLinuxContainer) {
                 is Arm32Hfp -> {
                     linuxArm32Hfp(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is Arm64 -> {
                     linuxArm64(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is Mips32 -> {
                     linuxMips32(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is Mipsel32 -> {
                     linuxMipsel32(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is X64 -> {
                     linuxX64(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
             }
@@ -159,11 +159,11 @@ public sealed class TargetLinuxContainer<T: KotlinNativeTarget> private construc
             with(sourceSets) {
                 getByName("${targetName}Main") { ss ->
                     ss.dependsOn(getByName("${LINUX}Main"))
-                    lazySourceSetMain?.execute(ss)
+                    lazySourceSetMain.forEach { action -> action.execute(ss) }
                 }
                 getByName("${targetName}Test") { ss ->
                     ss.dependsOn(getByName("${LINUX}Test"))
-                    lazySourceSetTest?.execute(ss)
+                    lazySourceSetTest.forEach { action -> action.execute(ss) }
                 }
             }
         }

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetMacosContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetMacosContainer.kt
@@ -76,12 +76,12 @@ public sealed class TargetMacosContainer<T: KotlinNativeTarget> private construc
             val target = when (this@TargetMacosContainer) {
                 is Arm64 -> {
                     macosArm64(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is X64 -> {
                     macosX64(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
             }
@@ -91,11 +91,11 @@ public sealed class TargetMacosContainer<T: KotlinNativeTarget> private construc
             with(sourceSets) {
                 getByName("${targetName}Main") { ss ->
                     ss.dependsOn(getByName("${MACOS}Main"))
-                    lazySourceSetMain?.execute(ss)
+                    lazySourceSetMain.forEach { action -> action.execute(ss) }
                 }
                 getByName("${targetName}Test") { ss ->
                     ss.dependsOn(getByName("${MACOS}Test"))
-                    lazySourceSetTest?.execute(ss)
+                    lazySourceSetTest.forEach { action -> action.execute(ss) }
                 }
             }
         }

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetMingwContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetMingwContainer.kt
@@ -76,12 +76,12 @@ public sealed class TargetMingwContainer<T: KotlinNativeTarget> private construc
             val target = when (this@TargetMingwContainer) {
                 is X64 -> {
                     mingwX64(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is X86 -> {
                     mingwX86(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
             }
@@ -91,11 +91,11 @@ public sealed class TargetMingwContainer<T: KotlinNativeTarget> private construc
             with(sourceSets) {
                 getByName("${targetName}Main") { ss ->
                     ss.dependsOn(getByName("${MINGW}Main"))
-                    lazySourceSetMain?.execute(ss)
+                    lazySourceSetMain.forEach { action -> action.execute(ss) }
                 }
                 getByName("${targetName}Test") { ss ->
                     ss.dependsOn(getByName("${MINGW}Test"))
-                    lazySourceSetTest?.execute(ss)
+                    lazySourceSetTest.forEach { action -> action.execute(ss) }
                 }
             }
         }

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetTvosContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetTvosContainer.kt
@@ -95,17 +95,17 @@ public sealed class TargetTvosContainer<T: KotlinNativeTarget> private construct
             val target = when (this@TargetTvosContainer) {
                 is Arm64 -> {
                     tvosArm64(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is SimulatorArm64 -> {
                     tvosSimulatorArm64(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is X64 -> {
                     tvosX64(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
             }
@@ -115,11 +115,11 @@ public sealed class TargetTvosContainer<T: KotlinNativeTarget> private construct
             with(sourceSets) {
                 getByName("${targetName}Main") { ss ->
                     ss.dependsOn(getByName("${TVOS}Main"))
-                    lazySourceSetMain?.execute(ss)
+                    lazySourceSetMain.forEach { action -> action.execute(ss) }
                 }
                 getByName("${targetName}Test") { ss ->
                     ss.dependsOn(getByName("${TVOS}Test"))
-                    lazySourceSetTest?.execute(ss)
+                    lazySourceSetTest.forEach { action -> action.execute(ss) }
                 }
             }
         }

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetWasmContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetWasmContainer.kt
@@ -78,7 +78,7 @@ public class TargetWasmContainer internal constructor(
         with(kotlin) {
             @Suppress("RedundantSamConstructor")
             val target = wasm(targetName, Action { t ->
-                lazyTarget?.execute(t)
+                lazyTarget.forEach { action -> action.execute(t) }
             })
 
             applyPlugins(target.project)
@@ -86,11 +86,11 @@ public class TargetWasmContainer internal constructor(
             with(sourceSets) {
                 getByName("${targetName}Main") { ss ->
                     ss.dependsOn(getByName("${NON_JVM}Main"))
-                    lazySourceSetMain?.execute(ss)
+                    lazySourceSetMain.forEach { action -> action.execute(ss) }
                 }
                 getByName("${targetName}Test") { ss ->
                     ss.dependsOn(getByName("${NON_JVM}Test"))
-                    lazySourceSetTest?.execute(ss)
+                    lazySourceSetTest.forEach { action -> action.execute(ss) }
                 }
             }
         }

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetWasmNativeContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetWasmNativeContainer.kt
@@ -59,7 +59,7 @@ public sealed class TargetWasmNativeContainer<T: KotlinNativeTarget> private con
             val target = when (this@TargetWasmNativeContainer) {
                 is _32 -> {
                     wasm32(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
             }
@@ -69,11 +69,11 @@ public sealed class TargetWasmNativeContainer<T: KotlinNativeTarget> private con
             with(sourceSets) {
                 getByName("${targetName}Main") { ss ->
                     ss.dependsOn(getByName("${WASM_NATIVE}Main"))
-                    lazySourceSetMain?.execute(ss)
+                    lazySourceSetMain.forEach { action -> action.execute(ss) }
                 }
                 getByName("${targetName}Test") { ss ->
                     ss.dependsOn(getByName("${WASM_NATIVE}Test"))
-                    lazySourceSetTest?.execute(ss)
+                    lazySourceSetTest.forEach { action -> action.execute(ss) }
                 }
             }
         }

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetWatchosContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetWatchosContainer.kt
@@ -156,32 +156,32 @@ public sealed class TargetWatchosContainer<T: KotlinNativeTarget> private constr
             val target = when (this@TargetWatchosContainer) {
                 is Arm32 -> {
                     watchosArm32(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is Arm64 -> {
                     watchosArm64(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is DeviceArm64 -> {
                     watchosDeviceArm64(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is SimulatorArm64 -> {
                     watchosSimulatorArm64(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is X64 -> {
                     watchosX64(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
                 is X86 -> {
                     watchosX86(targetName, Action { t ->
-                        lazyTarget?.execute(t)
+                        lazyTarget.forEach { action -> action.execute(t) }
                     })
                 }
             }
@@ -191,11 +191,11 @@ public sealed class TargetWatchosContainer<T: KotlinNativeTarget> private constr
             with(sourceSets) {
                 getByName("${targetName}Main") { ss ->
                     ss.dependsOn(getByName("${WATCHOS}Main"))
-                    lazySourceSetMain?.execute(ss)
+                    lazySourceSetMain.forEach { action -> action.execute(ss) }
                 }
                 getByName("${targetName}Test") { ss ->
                     ss.dependsOn(getByName("${WATCHOS}Test"))
-                    lazySourceSetTest?.execute(ss)
+                    lazySourceSetTest.forEach { action -> action.execute(ss) }
                 }
             }
         }


### PR DESCRIPTION
Closes #18 

Now projects who utilize composite builds can create an extension function in their `build-logic`/`build-support` module such that they can configure containers multiple times

```kotlin
// :build-logic
// shared.gradle.kts
plugins {
    id("io.matthewnelson.kmp.configuration")
}
```

```kotlin
// :build-logic
// KmpConfigurationExtensionExt.kt
fun KmpConfigurationExtension.configureShared(
    action: Action<KmpConfigurationContainerDsl>
) {
    configure {
        // configuration for all projects that apply the "shared" plugin generated by shared.gradle.kts
        jvm {
            target { withJava() }

            kotlinJvmTarget = JavaVersion.VERSION_1_8
            compileSourceCompatibility = JavaVersion.VERSION_1_8
            compileTargetCompatibility = JavaVersion.VERSION_1_8
        }

        js()
//        wasm()
        wasmNativeAll()

        androidNativeAll()

        iosAll()
        macosAll()
        tvosAll()
        watchosAll()

        linuxAll()
        mingwAll()

        common {
            sourceSetTest {
                dependencies {
                    implementation(kotlin("test"))
                }
            }
        }

        action.execute(this)
    }
}
```

```kotlin
// :my-project
// build.gradle.kts
plugins {
    id("shared")
}

kmpConfiguration {
    configureShared {
        common {
            sourceSetMain {
                dependencies {
                    implementation(project(":my-other-project"))
                }
            }
        }
    }
}
```