### PR TITLE
Check for null string value when finding `KMP_TARGETS`

### DIFF
--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/KmpTargetProperty.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/KmpTargetProperty.kt
@@ -60,6 +60,7 @@ internal enum class KmpTargetProperty {
         internal fun Project.findKmpTargetsProperties(): Set<KmpTargetProperty>? {
             return findProperty("KMP_TARGETS")
                 ?.toString()
+                ?.let { if (it.equals("null", ignoreCase = true)) return null else it }
                 ?.split(',')
                 ?.map { target ->
                     try {


### PR DESCRIPTION
closes #26 