### PR TITLE
Fix simulator source sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,10 +223,16 @@ kmpConfiguration {
 
         options {
             // Will create additional source sets for `iOS`, `tvOS`, and
-            // `watchOS` non-simulator targets to inherit from
+            // `watchOS` simulator targets to inherit from
+            //
+            // e.g. iosSimulator{Main/Test}
+            useSimulatorSourceSets = true
+            
+            // Will create additional source sets for `iOS`, `tvOS`, and
+            // `watchOS` NON-simulator targets to inherit from
             //
             // e.g. iosNonSimulator{Main/Test}
-            nonSimulatorSourceSets = true
+            useNonSimulatorSourceSets = true
         }
 
         androidNativeAll()

--- a/plugin/api/plugin.api
+++ b/plugin/api/plugin.api
@@ -30,8 +30,12 @@ public final class io/matthewnelson/kmp/configuration/extension/container/Contai
 }
 
 public final class io/matthewnelson/kmp/configuration/extension/container/OptionsContainer : io/matthewnelson/kmp/configuration/extension/container/Container {
-	public field nonSimulatorSourceSets Z
+	public field useNonSimulatorSourceSets Z
+	public field useSimulatorSourceSets Z
 	public static final synthetic fun findNonSimulator$plugin (Lorg/gradle/api/NamedDomainObjectContainer;Ljava/lang/String;Z)Lorg/jetbrains/kotlin/gradle/plugin/KotlinSourceSet;
+	public static final synthetic fun findSimulator$plugin (Lorg/gradle/api/NamedDomainObjectContainer;Ljava/lang/String;Z)Lorg/jetbrains/kotlin/gradle/plugin/KotlinSourceSet;
+	public final fun getNonSimulatorSourceSets ()Z
+	public final fun setNonSimulatorSourceSets (Z)V
 }
 
 public final class io/matthewnelson/kmp/configuration/extension/container/target/KmpConfigurationContainerDsl : io/matthewnelson/kmp/configuration/extension/container/target/TargetAndroidContainer$Configure, io/matthewnelson/kmp/configuration/extension/container/target/TargetAndroidNativeContainer$Configure, io/matthewnelson/kmp/configuration/extension/container/target/TargetIosContainer$Configure, io/matthewnelson/kmp/configuration/extension/container/target/TargetJsContainer$Configure, io/matthewnelson/kmp/configuration/extension/container/target/TargetJvmContainer$Configure, io/matthewnelson/kmp/configuration/extension/container/target/TargetLinuxContainer$Configure, io/matthewnelson/kmp/configuration/extension/container/target/TargetMacosContainer$Configure, io/matthewnelson/kmp/configuration/extension/container/target/TargetMingwContainer$Configure, io/matthewnelson/kmp/configuration/extension/container/target/TargetTvosContainer$Configure, io/matthewnelson/kmp/configuration/extension/container/target/TargetWasmContainer$Configure, io/matthewnelson/kmp/configuration/extension/container/target/TargetWasmNativeContainer$Configure, io/matthewnelson/kmp/configuration/extension/container/target/TargetWatchosContainer$Configure {

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetIosContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetIosContainer.kt
@@ -20,6 +20,7 @@ package io.matthewnelson.kmp.configuration.extension.container.target
 import io.matthewnelson.kmp.configuration.KmpConfigurationDsl
 import io.matthewnelson.kmp.configuration.extension.container.ContainerHolder
 import io.matthewnelson.kmp.configuration.extension.container.OptionsContainer.Companion.findNonSimulator
+import io.matthewnelson.kmp.configuration.extension.container.OptionsContainer.Companion.findSimulator
 import org.gradle.api.Action
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
@@ -138,7 +139,7 @@ public sealed class TargetIosContainer<T: KotlinNativeTarget> private constructo
                 is X64 -> {
                     iosX64(targetName, Action { t ->
                         lazyTarget.forEach { action -> action.execute(t) }
-                    }) to false
+                    }) to true
                 }
             }
 
@@ -149,7 +150,7 @@ public sealed class TargetIosContainer<T: KotlinNativeTarget> private constructo
                     val main = if (!isSimulator) {
                         findNonSimulator(IOS, isMain = true)
                     } else {
-                        null
+                        findSimulator(IOS, isMain = true)
                     } ?: getByName("${IOS}Main")
 
                     ss.dependsOn(main)
@@ -159,7 +160,7 @@ public sealed class TargetIosContainer<T: KotlinNativeTarget> private constructo
                     val test = if (!isSimulator) {
                         findNonSimulator(IOS, isMain = false)
                     } else {
-                        null
+                        findSimulator(IOS, isMain = false)
                     } ?: getByName("${IOS}Test")
 
                     ss.dependsOn(test)

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetTvosContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetTvosContainer.kt
@@ -18,6 +18,7 @@ package io.matthewnelson.kmp.configuration.extension.container.target
 import io.matthewnelson.kmp.configuration.KmpConfigurationDsl
 import io.matthewnelson.kmp.configuration.extension.container.ContainerHolder
 import io.matthewnelson.kmp.configuration.extension.container.OptionsContainer.Companion.findNonSimulator
+import io.matthewnelson.kmp.configuration.extension.container.OptionsContainer.Companion.findSimulator
 import org.gradle.api.Action
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
@@ -107,7 +108,7 @@ public sealed class TargetTvosContainer<T: KotlinNativeTarget> private construct
                 is X64 -> {
                     tvosX64(targetName, Action { t ->
                         lazyTarget.forEach { action -> action.execute(t) }
-                    }) to false
+                    }) to true
                 }
             }
 
@@ -118,7 +119,7 @@ public sealed class TargetTvosContainer<T: KotlinNativeTarget> private construct
                     val main = if (!isSimulator) {
                         findNonSimulator(TVOS, isMain = true)
                     } else {
-                        null
+                        findSimulator(TVOS, isMain = true)
                     } ?: getByName("${TVOS}Main")
 
                     ss.dependsOn(main)
@@ -128,7 +129,7 @@ public sealed class TargetTvosContainer<T: KotlinNativeTarget> private construct
                     val test = if (!isSimulator) {
                         findNonSimulator(TVOS, isMain = false)
                     } else {
-                        null
+                        findSimulator(TVOS, isMain = false)
                     } ?: getByName("${TVOS}Test")
 
                     ss.dependsOn(test)

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetWatchosContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetWatchosContainer.kt
@@ -20,6 +20,7 @@ package io.matthewnelson.kmp.configuration.extension.container.target
 import io.matthewnelson.kmp.configuration.KmpConfigurationDsl
 import io.matthewnelson.kmp.configuration.extension.container.ContainerHolder
 import io.matthewnelson.kmp.configuration.extension.container.OptionsContainer.Companion.findNonSimulator
+import io.matthewnelson.kmp.configuration.extension.container.OptionsContainer.Companion.findSimulator
 import org.gradle.api.Action
 import org.gradle.api.GradleException
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
@@ -187,7 +188,7 @@ public sealed class TargetWatchosContainer<T: KotlinNativeTarget> private constr
                 is X64 -> {
                     watchosX64(targetName, Action { t ->
                         lazyTarget.forEach { action -> action.execute(t) }
-                    }) to false
+                    }) to true
                 }
                 is X86 -> {
                     watchosX86(targetName, Action { t ->
@@ -203,7 +204,7 @@ public sealed class TargetWatchosContainer<T: KotlinNativeTarget> private constr
                     val main = if (!isSimulator) {
                         findNonSimulator(WATCHOS, isMain = true)
                     } else {
-                        null
+                        findSimulator(WATCHOS, isMain = true)
                     } ?: getByName("${WATCHOS}Main")
 
                     ss.dependsOn(main)
@@ -213,7 +214,7 @@ public sealed class TargetWatchosContainer<T: KotlinNativeTarget> private constr
                     val test = if (!isSimulator) {
                         findNonSimulator(WATCHOS, isMain = false)
                     } else {
-                        null
+                        findSimulator(WATCHOS, isMain = false)
                     } ?: getByName("${WATCHOS}Test")
 
                     ss.dependsOn(test)


### PR DESCRIPTION
Closes #39 

Deprecates the option `nonSimulatorSourceSets` in favor of `useSimulatorSourceSets` which will create `{ios/tvos/watchos}Simulators{Main/Test}` intermediary source set for which simulators will inherit from.