### PR TITLE
Move `androidNative` intermediary source set to inherit from `unix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ Will automatically configure project with a hierarchical source set structure
          |-- wasmJs
          |-- wasmWasi
          '-- native
-               |-- androidNative
-               |     |-- androidNativeArm32
-               |     |-- androidNativeArm64
-               |     |-- androidNativeX64
-               |     '-- androidNativeX86
                |-- unix
+               |     |-- androidNative
+               |     |     |-- androidNativeArm32
+               |     |     |-- androidNativeArm64
+               |     |     |-- androidNativeX64
+               |     |     '-- androidNativeX86
                |     |-- darwin
                |     |     |-- ios
                |     |     |     |-- iosArm32
@@ -312,13 +312,13 @@ kmpConfiguration {
                 if (linuxMain != null || androidNativeMain != null) {
                     val linuxAndroidMain = maybeCreate("linuxAndroidMain").apply {
                         // `linux` and `androidNative` intermediate source sets
-                        // inherit from native, so it will always be available
+                        // inherit from unix, so it will always be available
                         // if either of them are configured. So, we can use
                         // `getByName` safely.
-                        dependsOn(getByName("nativeMain"))
+                        dependsOn(getByName("unixMain"))
                     }
                     val linuxAndroidTest = maybeCreate("linuxAndroidTest").apply {
-                        dependsOn(getByName("nativeTest"))
+                        dependsOn(getByName("unixTest"))
                     }
 
                     linuxMain?.apply { dependsOn(linuxAndroidMain) }

--- a/plugin/api/plugin.api
+++ b/plugin/api/plugin.api
@@ -175,15 +175,15 @@ public abstract class io/matthewnelson/kmp/configuration/extension/container/tar
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
-public abstract class io/matthewnelson/kmp/configuration/extension/container/target/KmpTarget$NonJvm$Native$Android : io/matthewnelson/kmp/configuration/extension/container/target/KmpTarget$NonJvm$Native {
-	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-}
-
 public abstract class io/matthewnelson/kmp/configuration/extension/container/target/KmpTarget$NonJvm$Native$Mingw : io/matthewnelson/kmp/configuration/extension/container/target/KmpTarget$NonJvm$Native {
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public abstract class io/matthewnelson/kmp/configuration/extension/container/target/KmpTarget$NonJvm$Native$Unix : io/matthewnelson/kmp/configuration/extension/container/target/KmpTarget$NonJvm$Native {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public abstract class io/matthewnelson/kmp/configuration/extension/container/target/KmpTarget$NonJvm$Native$Unix$Android : io/matthewnelson/kmp/configuration/extension/container/target/KmpTarget$NonJvm$Native$Unix {
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
@@ -246,7 +246,7 @@ public final class io/matthewnelson/kmp/configuration/extension/container/target
 public final class io/matthewnelson/kmp/configuration/extension/container/target/TargetAndroidContainer$Library : io/matthewnelson/kmp/configuration/extension/container/target/TargetAndroidContainer {
 }
 
-public abstract class io/matthewnelson/kmp/configuration/extension/container/target/TargetAndroidNativeContainer : io/matthewnelson/kmp/configuration/extension/container/target/KmpTarget$NonJvm$Native$Android {
+public abstract class io/matthewnelson/kmp/configuration/extension/container/target/TargetAndroidNativeContainer : io/matthewnelson/kmp/configuration/extension/container/target/KmpTarget$NonJvm$Native$Unix$Android {
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/KmpConfigurationPlugin.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/KmpConfigurationPlugin.kt
@@ -128,12 +128,6 @@ public open class KmpConfigurationPlugin : Plugin<Project> {
                     dependsOn(nonJvmTest)
                 }
 
-                val androidNativeTargets = nativeTargets.filterIsInstance<KmpTarget.NonJvm.Native.Android<*>>()
-                if (androidNativeTargets.isNotEmpty()) {
-                    maybeCreate("${TargetAndroidNativeContainer.ANDROID_NATIVE}Main").dependsOn(nativeMain)
-                    maybeCreate("${TargetAndroidNativeContainer.ANDROID_NATIVE}Test").dependsOn(nativeTest)
-                }
-
                 val unixTargets = nativeTargets.filterIsInstance<KmpTarget.NonJvm.Native.Unix<*>>()
                 if (unixTargets.isNotEmpty()) {
                     val unixMain = maybeCreate("${KmpTarget.NonJvm.Native.Unix.UNIX}Main").apply {
@@ -141,6 +135,12 @@ public open class KmpConfigurationPlugin : Plugin<Project> {
                     }
                     val unixTest = maybeCreate("${KmpTarget.NonJvm.Native.Unix.UNIX}Test").apply {
                         dependsOn(nativeTest)
+                    }
+
+                    val androidNativeTargets = unixTargets.filterIsInstance<KmpTarget.NonJvm.Native.Unix.Android<*>>()
+                    if (androidNativeTargets.isNotEmpty()) {
+                        maybeCreate("${TargetAndroidNativeContainer.ANDROID_NATIVE}Main").dependsOn(unixMain)
+                        maybeCreate("${TargetAndroidNativeContainer.ANDROID_NATIVE}Test").dependsOn(unixTest)
                     }
 
                     val darwinTargets = unixTargets.filterIsInstance<KmpTarget.NonJvm.Native.Unix.Darwin<*>>()

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/KmpTarget.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/KmpTarget.kt
@@ -47,11 +47,11 @@ public sealed class KmpTarget<T: KotlinTarget> private constructor(
 
             internal companion object { internal const val NATIVE = "native" }
 
-            public sealed class Android<T: KotlinNativeTarget>(targetName: String): Native<T>(targetName)
-
             public sealed class Unix<T: KotlinNativeTarget>(targetName: String): Native<T>(targetName) {
 
                 internal companion object { internal const val UNIX = "unix" }
+
+                public sealed class Android<T: KotlinNativeTarget>(targetName: String): Unix<T>(targetName)
 
                 public sealed class Darwin<T: KotlinNativeTarget>(targetName: String): Unix<T>(targetName) {
 

--- a/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetAndroidNativeContainer.kt
+++ b/plugin/src/main/kotlin/io/matthewnelson/kmp/configuration/extension/container/target/TargetAndroidNativeContainer.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 public sealed class TargetAndroidNativeContainer<T: KotlinNativeTarget> private constructor(
     targetName: String
-): KmpTarget.NonJvm.Native.Android<T>(targetName) {
+): KmpTarget.NonJvm.Native.Unix.Android<T>(targetName) {
 
     public sealed interface Configure {
         public val holder: ContainerHolder


### PR DESCRIPTION
Closes #41 

`androidNative` now inherits from `unix` instead of `native`